### PR TITLE
Refactored CRCPBasic in C wrappers and tests

### DIFF
--- a/symengine/cwrapper.cpp
+++ b/symengine/cwrapper.cpp
@@ -11,6 +11,7 @@
 #include <symengine/add.h>
 #include <symengine/number.h>
 #include <symengine/constants.h>
+#include <symengine/visitor.h>
 
 using SymEngine::Basic;
 using SymEngine::RCP;
@@ -22,9 +23,9 @@ using SymEngine::Number;
 using SymEngine::rcp_static_cast;
 using SymEngine::is_a;
 
-#define RCP_cast_general(x, CONST) (reinterpret_cast<CONST RCP<const Basic> *>(x))
-#define RCP_cast(x) RCP_cast_general(x, )
-#define RCP_const_cast(x) RCP_cast_general(x, const)
+// #define RCP_cast_general(x, CONST) (reinterpret_cast<CONST RCP<const Basic> *>(x))
+// #define RCP_cast(x) RCP_cast_general(x, )
+// #define RCP_const_cast(x) RCP_cast_general(x, const)
 
 namespace SymEngine {
 
@@ -38,174 +39,57 @@ inline bool is_aligned( T*p, size_t n = alignof(T) ){
 
 extern "C" {
 
-void basic_init(basic s)
-{
-    // These checks only happen at compile time.
-    // Check that 'basic' has the correct size:
-    static_assert(sizeof(RCP<const Basic>) == sizeof(basic), "Size of 'basic' is not correct");
-    // Check that 'basic' has the correct alignment:
-    static_assert(std::alignment_of<RCP<const Basic>>::value == std::alignment_of<basic>::value, "Alignment of 'basic' is not correct");
+// void basic_init(basic s)
+// {
+// #if defined(WITH_SYMENGINE_RCP)
+//     // These checks only happen at compile time.
+//     // Check that 'basic' has the correct size:
+//     static_assert(sizeof(RCP<const Basic>) == sizeof(basic), "Size of 'basic' is not correct");
+//     // Check that 'basic' has the correct alignment:
+//     static_assert(std::alignment_of<RCP<const Basic>>::value == std::alignment_of<basic>::value, "Alignment of 'basic' is not correct");
+// #else
+//     throw std::runtime_error("Teuchos::RCP is not compatible with the C wrappers");
+// #endif
+//     // No allocation is being done, but the constructor of RCP is called and
+//     // the instance is initialized at the memory address 's'. The above checks
+//     // make sure that 's' has the correct size and alignment, which is
+//     // necessary for placement new, otherwise the results are undefined.
+//     new(s) RCP<const Basic>();
+// }
+//
+// void basic_free(basic s)
+// {
+//     RCP_cast(s)->~RCP();
+// }
 
-    // No allocation is being done, but the constructor of RCP is called and
-    // the instance is initialized at the memory address 's'. The above checks
-    // make sure that 's' has the correct size and alignment, which is
-    // necessary for placement new, otherwise the results are undefined.
-    new(s) RCP<const Basic>();
-}
+// C wrapper for SymEngine::RCP<const SymEngine::Basic>
 
-void basic_free(basic s)
-{
-    RCP_cast(s)->~RCP();
-}
+struct CRCPBasic {
+    RCP<const Basic> m;
+};
 
-void symbol_set(basic s, char* c)
+CRCPBasic* basic_new()
 {
-    *RCP_cast(s) = SymEngine::symbol(std::string(c));
-}
-
-void integer_set_si(basic s, long i)
-{
-    *RCP_cast(s) = SymEngine::integer(mpz_class(i));
-}
-
-void integer_set_ui(basic s, unsigned long i)
-{
-    *RCP_cast(s) = SymEngine::integer(mpz_class(i));
-}
-
-void integer_set_mpz(basic s, const mpz_t i)
-{
-    *RCP_cast(s) = SymEngine::integer(mpz_class(i));
+    return new CRCPBasic;
 }
 
-void integer_set_str(basic s, char* c)
+int basic_placement_new(CRCPBasic *self, size_t size)
 {
-    *RCP_cast(s) = SymEngine::integer(mpz_class(c, 10));
+    if (!SymEngine::is_aligned(self)) return ENOTALIGNED;
+    if (size < sizeof(CRCPBasic)) return EINSUFFSIZE;
+    new(self) CRCPBasic;
+    return 0;
 }
 
-signed long integer_get_si(const basic s)
+void basic_free(CRCPBasic *self)
 {
-    SYMENGINE_ASSERT(is_a<Integer>(*(*RCP_const_cast(s))));
-    return mpz_get_si((rcp_static_cast<const Integer>(*RCP_const_cast(s)))->as_mpz().get_mpz_t());
+    delete self;
 }
 
-unsigned long integer_get_ui(const basic s)
+void basic_placement_free(CRCPBasic *self)
 {
-    SYMENGINE_ASSERT(is_a<Integer>(*(*RCP_const_cast(s))));
-    return mpz_get_ui((rcp_static_cast<const Integer>(*RCP_const_cast(s)))->as_mpz().get_mpz_t());
+    self->m.~RCP();
 }
-
-void integer_get_mpz(mpz_t a, const basic s)
-{
-    SYMENGINE_ASSERT(is_a<Integer>(*(*RCP_const_cast(s))));
-    mpz_set(a, (rcp_static_cast<const Integer>(*RCP_const_cast(s)))->as_mpz().get_mpz_t());
-}
-
-void rational_set_si(basic s, long a, long b)
-{
-    *RCP_cast(s) = SymEngine::Rational::from_mpq(mpq_class(a, b));
-}
-
-void rational_set_ui(basic s, unsigned long a, unsigned long b)
-{
-    *RCP_cast(s) = SymEngine::Rational::from_mpq(mpq_class(a, b));
-}
-
-int rational_set(basic s, const basic a, const basic b)
-{
-    if (!is_a_Integer(a) || !is_a_Integer(b)) {
-        return 0;
-    }
-    *RCP_cast(s) = SymEngine::Rational::from_two_ints(
-            rcp_static_cast<const Integer>(*RCP_const_cast(a)),
-            rcp_static_cast<const Integer>(*RCP_const_cast(b)));
-    return 1;
-}
-
-void rational_set_mpq(basic s, const mpq_t i)
-{
-    *RCP_cast(s) = SymEngine::Rational::from_mpq(mpq_class(i));
-}
-
-int basic_diff(basic s, const basic expr, basic const symbol)
-{
-    if (!is_a_Symbol(symbol))
-        return 0;
-    *RCP_cast(s) = (*RCP_const_cast(expr))->diff(rcp_static_cast<const Symbol>
-            (*RCP_const_cast(symbol)));
-    return 1;
-}
-
-void basic_assign(basic a, const basic b) {
-    *RCP_cast(a) = RCP<const Basic>(*RCP_const_cast(b));
-}
-
-void basic_add(basic s, const basic a, const basic b)
-{
-    *RCP_cast(s) = SymEngine::add(*RCP_const_cast(a), *RCP_const_cast(b));
-}
-
-void basic_sub(basic s, const basic a, const basic b)
-{
-    *RCP_cast(s) = SymEngine::sub(*RCP_const_cast(a), *RCP_const_cast(b));
-}
-
-void basic_mul(basic s, const basic a, const basic b)
-{
-    *RCP_cast(s) = SymEngine::mul(*RCP_const_cast(a), *RCP_const_cast(b));
-}
-
-void basic_pow(basic s, const basic a, const basic b)
-{
-    *RCP_cast(s) = SymEngine::pow(*RCP_const_cast(a), *RCP_const_cast(b));
-}
-
-void basic_div(basic s, const basic a, const basic b)
-{
-    *RCP_cast(s) = SymEngine::div(*RCP_const_cast(a), *RCP_const_cast(b));
-}
-
-void basic_neg(basic s, const basic a)
-{
-    *RCP_cast(s) = SymEngine::neg(*RCP_const_cast(a));
-}
-
-void basic_abs(basic s, const basic a)
-{
-    *RCP_cast(s) = SymEngine::abs(*RCP_const_cast(a));
-}
-
-void basic_expand(basic s, const basic a)
-{
-    *RCP_cast(s) = SymEngine::expand(*RCP_const_cast(a));
-}
-
-char* basic_str(const basic s)
-{
-    std::string str = (*RCP_const_cast(s))->__str__();
-    char *cc = new char[str.length()+1];
-    std::strcpy(cc, str.c_str());
-    return cc;
-}
-
-void basic_str_free(char* s)
-{
-    delete[] s;
-}
-
-int is_a_Integer(const basic c)
-{
-    return is_a<Integer>(*(*RCP_const_cast(c)));
-}
-int is_a_Rational(const basic c)
-{
-    return is_a<Rational>(*(*RCP_const_cast(c)));
-}
-int is_a_Symbol(const basic c)
-{
-    return is_a<Symbol>(*(*RCP_const_cast(c)));
-}
-
 
 // C wrapper for std::vector<int>
 
@@ -220,8 +104,8 @@ CVectorInt* vectorint_new()
 
 int vectorint_placement_new(CVectorInt *self, size_t size)
 {
-    if (!SymEngine::is_aligned(self)) return 2;
-    if (size < sizeof(CVectorInt)) return 1;
+    if (!SymEngine::is_aligned(self)) return ENOTALIGNED;
+    if (size < sizeof(CVectorInt)) return EINSUFFSIZE;
     new(self) CVectorInt;
     return 0;
 }
@@ -241,7 +125,6 @@ int vectorint_get(CVectorInt *self, int n)
     return self->m[n];
 }
 
-
 // C wrapper for vec_basic
 
 struct CVecBasic {
@@ -258,14 +141,14 @@ void vecbasic_free(CVecBasic *self)
     delete self;
 }
 
-void vecbasic_push_back(CVecBasic *self, const basic value)
+void vecbasic_push_back(CVecBasic *self, const CRCPBasic *value)
 {
-    self->m.push_back(*RCP_const_cast(value));
+    self->m.push_back(value->m);
 }
 
-void vecbasic_get(CVecBasic *self, int n, basic result)
+void vecbasic_get(CVecBasic *self, int n, CRCPBasic *result)
 {
-    *RCP_cast(result) = self->m[n];
+    result->m = self->m[n];
 }
 
 size_t vecbasic_size(CVecBasic *self)
@@ -273,11 +156,204 @@ size_t vecbasic_size(CVecBasic *self)
     return self->m.size();
 }
 
+// C Wrapper for set_basic
+
+struct CSetBasic {
+    SymEngine::set_basic m;
+};
+
+CSetBasic* setbasic_new()
+{
+    return new CSetBasic;
+}
+
+void setbasic_free(CSetBasic *self)
+{
+    delete self;
+}
+
+int setbasic_insert(CSetBasic *self, const CRCPBasic *value)
+{
+    return (self->m.insert(value->m)).second ? 1 : 0;
+}
+
+int setbasic_find(CSetBasic *self, CRCPBasic *value)
+{
+    return self->m.find(value->m) != (self->m).end() ? 1 : 0;
+}
+
+size_t setbasic_size(CSetBasic *self)
+{
+    return self->m.size();
+}
+
 // ----------------------
 
-void basic_get_args(const basic self, CVecBasic *args)
+void basic_free_symbols(const CRCPBasic *self, CSetBasic *symbols)
 {
-    args->m = (*RCP_const_cast(self))->get_args();
+    symbols->m = SymEngine::free_symbols(*(self->m));
+}
+
+void basic_get_args(const CRCPBasic *self, CVecBasic *args)
+{
+    args->m = self->m->get_args();
+}
+
+void symbol_set(CRCPBasic* self, char* c)
+{
+    self->m = SymEngine::symbol(std::string(c));
+}
+
+void integer_set_si(CRCPBasic* self, long i)
+{
+    self->m = SymEngine::integer(mpz_class(i));
+}
+
+void integer_set_ui(CRCPBasic* self, unsigned long i)
+{
+    self->m = SymEngine::integer(mpz_class(i));
+}
+
+void integer_set_mpz(CRCPBasic* self, const mpz_t i)
+{
+    self->m = SymEngine::integer(mpz_class(i));
+}
+
+void integer_set_str(CRCPBasic* self, char* c)
+{
+    self->m = SymEngine::integer(mpz_class(c, 10));
+}
+
+signed long integer_get_si(const CRCPBasic *self)
+{
+    SYMENGINE_ASSERT(is_a_Integer(self));
+    return mpz_get_si((rcp_static_cast<const Integer>(self->m))->as_mpz().get_mpz_t());
+}
+
+unsigned long integer_get_ui(const CRCPBasic *self)
+{
+    SYMENGINE_ASSERT(is_a_Integer(self));
+    return mpz_get_ui((rcp_static_cast<const Integer>(self->m))->as_mpz().get_mpz_t());
+}
+
+void integer_get_mpz(mpz_t a, const CRCPBasic *self)
+{
+    SYMENGINE_ASSERT(is_a_Integer(self));
+    mpz_set(a, (rcp_static_cast<const Integer>(self->m))->as_mpz().get_mpz_t());
+}
+
+void rational_set_si(CRCPBasic* self, long a, long b)
+{
+    self->m = SymEngine::Rational::from_mpq(mpq_class(a, b));
+}
+
+void rational_set_ui(CRCPBasic* self, unsigned long a, unsigned long b)
+{
+    self->m = SymEngine::Rational::from_mpq(mpq_class(a, b));
+}
+
+int rational_set(CRCPBasic* self, const CRCPBasic *a, const CRCPBasic *b)
+{
+    if (!is_a_Integer(a) || !is_a_Integer(b)) {
+        return 0;
+    }
+    self->m = SymEngine::Rational::from_two_ints(
+            rcp_static_cast<const Integer>(a->m),
+            rcp_static_cast<const Integer>(a->m));
+    return 1;
+}
+
+void rational_set_mpq(CRCPBasic* self, const mpq_t i)
+{
+    self->m = SymEngine::Rational::from_mpq(mpq_class(i));
+}
+
+int basic_diff(CRCPBasic* result, const CRCPBasic *expr, const CRCPBasic *symbol)
+{
+    if (!is_a_Symbol(symbol))
+        return 0;
+    result->m = expr->m->diff(rcp_static_cast<const Symbol>(symbol->m));
+    return 1;
+}
+
+void basic_assign(CRCPBasic* a, const CRCPBasic *b) {
+    a->m = RCP<const Basic>(b->m);
+}
+
+void basic_add(CRCPBasic* result, const CRCPBasic *a, const CRCPBasic *b)
+{
+    result->m = SymEngine::add(a->m, b->m);
+}
+
+void basic_sub(CRCPBasic* result, const CRCPBasic *a, const CRCPBasic *b)
+{
+    result->m = SymEngine::sub(a->m, b->m);
+}
+
+void basic_mul(CRCPBasic* result, const CRCPBasic *a, const CRCPBasic *b)
+{
+    result->m = SymEngine::mul(a->m, b->m);
+}
+
+void basic_pow(CRCPBasic* result, const CRCPBasic *a, const CRCPBasic *b)
+{
+    result->m = SymEngine::pow(a->m, b->m);
+}
+
+void basic_div(CRCPBasic* result, const CRCPBasic *a, const CRCPBasic *b)
+{
+    result->m = SymEngine::div(a->m, b->m);
+}
+
+void basic_neg(CRCPBasic* result, const CRCPBasic *a)
+{
+    result->m = SymEngine::neg(a->m);
+}
+
+int basic_eq(const CRCPBasic *a, const CRCPBasic *b)
+{
+    return (SymEngine::eq(a->m, b->m)) ? 1 : 0;
+}
+
+int basic_neq(const CRCPBasic *a, const CRCPBasic *b)
+{
+    return (SymEngine::neq(a->m, b->m)) ? 1 : 0;
+}
+
+void basic_abs(CRCPBasic* result, const CRCPBasic *a)
+{
+    result->m = SymEngine::abs(a->m);
+}
+
+void basic_expand(CRCPBasic* result, const CRCPBasic *a)
+{
+    result->m = SymEngine::expand(a->m);
+}
+
+char* basic_str(const CRCPBasic *self)
+{
+    std::string str = self->m->__str__();
+    char *cc = new char[str.length()+1];
+    std::strcpy(cc, str.c_str());
+    return cc;
+}
+
+void basic_str_free(char* s)
+{
+    delete[] s;
+}
+
+int is_a_Integer(const CRCPBasic *c)
+{
+    return is_a<Integer>(*(c->m));
+}
+int is_a_Rational(const CRCPBasic *c)
+{
+    return is_a<Rational>(*(c->m));
+}
+int is_a_Symbol(const CRCPBasic *c)
+{
+    return is_a<Symbol>(*(c->m));
 }
 
 }

--- a/symengine/cwrapper.h
+++ b/symengine/cwrapper.h
@@ -4,9 +4,14 @@
 #include <stdlib.h>
 #include <gmp.h>
 
+//! Error codes
+//! Better name suggestions needed
+#define ENOTALIGNED 2
+#define EINSUFFSIZE 1
+
 #ifdef __cplusplus
 extern "C" {
-#endif
+#endif //__cplusplus
 
 // The size of 'basic_struct' must be the same as RCP<const Basic> *and* they
 // must have the same alignment (because we allocate RCP<const Basic> into the
@@ -42,71 +47,84 @@ typedef struct
 typedef basic_struct basic[1];
 
 
-//! Initialize a new basic instance.
-void basic_init(basic s);
-//! Assign value of b to a.
-void basic_assign(basic a, const basic b);
-//! Free the C++ class wrapped by s.
-void basic_free(basic s);
+// //! Initialize a new basic instance.
+// void basic_init(basic s);
+// //! Assign value of b to a.
+// void basic_assign(basic a, const basic b);
+// //! Free the C++ class wrapped by s.
+// void basic_free(basic s);
+
+//! Wrapper for SymEngine::RCP<const Basic>
+
+typedef struct CRCPBasic CRCPBasic;
+
+CRCPBasic* basic_new();
+int basic_placement_new(CRCPBasic *self, size_t size);
+void basic_free(CRCPBasic *self);
+void basic_placement_free(CRCPBasic *self);
 
 //! Assign to s, a symbol with string representation c.
-void symbol_set(basic s, char* c);
+void symbol_set(CRCPBasic* self, char* c);
 
 //! Assign to s, a long.
-void integer_set_si(basic s, long i);
+void integer_set_si(CRCPBasic* self, long i);
 //! Assign to s, a ulong.
-void integer_set_ui(basic s, unsigned long i);
+void integer_set_ui(CRCPBasic* self, unsigned long i);
 //! Assign to s, a mpz_t.
-void integer_set_mpz(basic s, const mpz_t i);
+void integer_set_mpz(CRCPBasic* self, const mpz_t i);
 //! Assign to s, an integer that has base 10 representation c.
-void integer_set_str(basic s, char* c);
+void integer_set_str(CRCPBasic* self, char* c);
 
 //! Returns signed long value of s.
-signed long integer_get_si(const basic s);
+signed long integer_get_si(const CRCPBasic* self);
 //! Returns unsigned long value of s.
-unsigned long integer_get_ui(const basic s);
+unsigned long integer_get_ui(const CRCPBasic* self);
 //! Returns s as a mpz_t.
-void integer_get_mpz(mpz_t a, const basic s);
+void integer_get_mpz(mpz_t a, const CRCPBasic* self);
 
 //! Assign to s, a rational i/j. Returns 0 if either i or j is not an integer.
-int rational_set(basic s, const basic i, const basic j);
+int rational_set(CRCPBasic* self, const CRCPBasic* i, const CRCPBasic* j);
 //! Assign to s, a rational i/j, where i and j are signed longs.
-void rational_set_si(basic s, long i, long j);
+void rational_set_si(CRCPBasic* self, long i, long j);
 //! Assign to s, a rational i/j, where i and j are unsigned longs.
-void rational_set_ui(basic s, unsigned long i, unsigned long j);
+void rational_set_ui(CRCPBasic* self, unsigned long i, unsigned long j);
 //! Assign to s, a rational i, where is of type mpq_t.
-void rational_set_mpq(basic s, const mpq_t i);
+void rational_set_mpq(CRCPBasic* self, const mpq_t i);
 
 //! Assigns s = a + b.
-void basic_add(basic s, const basic a, const basic b);
+void basic_add(CRCPBasic* result, const CRCPBasic* a, const CRCPBasic* b);
 //! Assigns s = a - b.
-void basic_sub(basic s, const basic a, const basic b);
+void basic_sub(CRCPBasic* result, const CRCPBasic* a, const CRCPBasic* b);
 //! Assigns s = a * b.
-void basic_mul(basic s, const basic a, const basic b);
+void basic_mul(CRCPBasic* result, const CRCPBasic* a, const CRCPBasic* b);
 //! Assigns s = a / b.
-void basic_div(basic s, const basic a, const basic b);
+void basic_div(CRCPBasic* result, const CRCPBasic* a, const CRCPBasic* b);
 //! Assigns s = a ** b.
-void basic_pow(basic s, const basic a, const basic b);
+void basic_pow(CRCPBasic* result, const CRCPBasic* a, const CRCPBasic* b);
 //! Assign to s, derivative of expr with respect to sym. Returns 0 if sym is not a symbol.
-int basic_diff(basic s, const basic expr, const basic sym);
+int basic_diff(CRCPBasic* result, const CRCPBasic* expr, const CRCPBasic* sym);
 //! Assigns s = -a.
-void basic_neg(basic s, const basic a);
+void basic_neg(CRCPBasic* result, const CRCPBasic* a);
+//! Returns 1 if both basic are equal, 0 if not
+int basic_eq(const CRCPBasic* a, const CRCPBasic* b);
+//! Returns 1 if both basic are not equal, 0 if they are
+int basic_neq(const CRCPBasic* a, const CRCPBasic* b);
 //! Assigns s = abs(a).
-void basic_abs(basic s, const basic a);
+void basic_abs(CRCPBasic* result, const CRCPBasic* a);
 //! Expands the expr a and assigns to s.
-void basic_expand(basic s, const basic a);
+void basic_expand(CRCPBasic* result, const CRCPBasic* a);
 
 //! Returns a new char pointer to the string representation of s.
-char* basic_str(const basic s);
+char* basic_str(const CRCPBasic* self);
 //! Frees the string s
 void basic_str_free(char* s);
 
 //! Return 1 if s is an Integer, 0 if not.
-int is_a_Integer(const basic s);
+int is_a_Integer(const CRCPBasic *self);
 //! Return 1 if s is an Rational, 0 if not.
-int is_a_Rational(const basic s);
+int is_a_Rational(const CRCPBasic *self);
 //! Return 1 if s is an Symbol, 0 if not.
-int is_a_Symbol(const basic s);
+int is_a_Symbol(const CRCPBasic *self);
 
 
 //! Wrapper for std::vector<int>
@@ -131,15 +149,29 @@ typedef struct CVecBasic CVecBasic;
 
 CVecBasic* vecbasic_new();
 void vecbasic_free(CVecBasic *self);
-void vecbasic_push_back(CVecBasic *self, const basic value);
-void vecbasic_get(CVecBasic *self, int n, basic result);
+void vecbasic_push_back(CVecBasic *self, const CRCPBasic *value);
+void vecbasic_get(CVecBasic *self, int n, CRCPBasic *result);
 size_t vecbasic_size(CVecBasic *self);
 
+//! Wrapper for set_basic
+
+typedef struct CSetBasic CSetBasic;
+CSetBasic* setbasic_new();
+void setbasic_free(CSetBasic *self);
+//! Returns 1 if insert is successful and 0 if set already contains the value
+//! and insertion is unsuccessful
+int setbasic_insert(CSetBasic *self, const CRCPBasic *value);
+//! Returns 1 if value is found in the set and 0 if not
+int setbasic_find(CSetBasic *self, CRCPBasic *value);
+size_t setbasic_size(CSetBasic *self);
 // -------------------------------------
 
-void basic_get_args(const basic self, CVecBasic *args);
+//! Returns a CSetBasic of set_basic given by free_symbols
+void basic_free_symbols(const CRCPBasic *self, CSetBasic *symbols);
+//! Returns a CVecBasic of vec_basic given by get_args
+void basic_get_args(const CRCPBasic *self, CVecBasic *args);
 
 #ifdef __cplusplus
 }
-#endif
-#endif
+#endif //__cplusplus
+#endif //CWRAPPER_H

--- a/symengine/tests/cwrapper/test_cwrapper.c
+++ b/symengine/tests/cwrapper/test_cwrapper.c
@@ -4,10 +4,10 @@
 
 void test_cwrapper() {
     char* s;
-    basic x, y, z;
-    basic_init(x);
-    basic_init(y);
-    basic_init(z);
+    CRCPBasic x[1], y[1], z[1];
+    if (basic_placement_new(x,sizeof(x))) printf("Error in making x\n");
+    basic_placement_new(y,sizeof(y));
+    basic_placement_new(z,sizeof(z));
     symbol_set(x, "x");
     symbol_set(y, "y");
     symbol_set(z, "z");
@@ -15,8 +15,8 @@ void test_cwrapper() {
     s = basic_str(x);
     printf("Symbol : %s\n", s);
     basic_str_free(s);
-    basic e;
-    basic_init(e);
+    CRCPBasic e[1];
+    basic_placement_new(e,sizeof(e));
 
     integer_set_ui(e, 123);
     s = basic_str(e);
@@ -57,10 +57,10 @@ void test_cwrapper() {
     printf("integer_get_mpz(e): %ld\n", mpz_get_ui(test));
 
     mpz_clear(test);
-    basic_free(e);
-    basic_free(x);
-    basic_free(y);
-    basic_free(z);
+    basic_placement_free(e);
+    basic_placement_free(x);
+    basic_placement_free(y);
+    basic_placement_free(z);
     basic_str_free(s);
 }
 
@@ -104,30 +104,32 @@ void test_CVecBasic()
     CVecBasic *vec = vecbasic_new();
     assert(vecbasic_size(vec) == 0);
 
-    basic x;
-    basic_init(x);
+    CRCPBasic x[1];
+    basic_placement_new(x,sizeof(x));
     symbol_set(x, "x");
     vecbasic_push_back(vec, x);
 
     assert(vecbasic_size(vec) == 1);
 
-    basic y;
-    basic_init(y);
+    CRCPBasic y[1];
+    basic_placement_new(y,sizeof(y));
     vecbasic_get(vec, 0, y);
 
     // TODO: enable this once basic_eq() is implemented
-    // assert(basic_eq(x, y));
+    assert(basic_eq(x, y));
 
     vecbasic_free(vec);
+    basic_placement_free(x);
+    basic_placement_free(y);
 }
 
 void test_get_args()
 {
-    basic x, y, z, e;
-    basic_init(x);
-    basic_init(y);
-    basic_init(z);
-    basic_init(e);
+    CRCPBasic x[1], y[1], z[1], e[1];
+    basic_placement_new(x,sizeof(x));
+    basic_placement_new(y,sizeof(y));
+    basic_placement_new(z,sizeof(z));
+    basic_placement_new(e,sizeof(e));
     symbol_set(x, "x");
     symbol_set(y, "y");
     symbol_set(z, "z");
@@ -142,10 +144,10 @@ void test_get_args()
     assert(vecbasic_size(args) == 3);
     vecbasic_free(args);
 
-    basic_free(e);
-    basic_free(x);
-    basic_free(y);
-    basic_free(z);
+    basic_placement_free(e);
+    basic_placement_free(x);
+    basic_placement_free(y);
+    basic_placement_free(z);
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
Regarding [PR#495](https://github.com/sympy/symengine/pull/495)

> And that's how we need to allocate the `CRCPBasic` type. The approach of `vectorint_placement_new` is very general, since the C wrappers do not know its size, but for `CRCPBasic` we know its size, so we'll use the same trick that we already implemented in `basic_init`.

This is still pending. Meanwhile in the tests, I am getting [this](https://gist.github.com/abinashmeher999/38138341fbd9ac5c867e) error. I am not able to find the reason. I will fix this before adding the refactored Ruby C wrappers. The next target is to make the ctests `test_cwrapper` pass before adding the refactored Ruby C wrappers.
